### PR TITLE
Use tempdir for maven cache by default

### DIFF
--- a/man/install_mleap.Rd
+++ b/man/install_mleap.Rd
@@ -4,12 +4,16 @@
 \alias{install_mleap}
 \title{Install MLeap runtime}
 \usage{
-install_mleap(dir = NULL, version = NULL)
+install_mleap(dir = NULL, version = NULL, use_temp_cache = TRUE)
 }
 \arguments{
 \item{dir}{(Optional) Directory to save the jars}
 
 \item{version}{Version of MLeap to install, defaults to the latest version tested with this package.}
+
+\item{use_temp_cache}{Whether to use a temporary Maven cache directory for downloading.
+Setting this to \code{TRUE} prevents Maven from creating a persistent \code{.m2/} directory.
+Defaults to \code{TRUE}.}
 }
 \description{
 Install MLeap runtime

--- a/tests/testthat/helpers-initialize.R
+++ b/tests/testthat/helpers-initialize.R
@@ -35,8 +35,6 @@ testthat_spark_connection <- function() {
     sc <- tryCatch({
       sparklyr::spark_connect(master = "local", version = version, config = config)
     }, error = function(e) {
-      system("rm -rf $HOME/.ivy2")
-      system("rm -rf /home/travis/.m2")
       sparklyr::spark_connect(master = "local", version = version, config = config)
     })
     assign(".testthat_spark_connection", sc, envir = .GlobalEnv)


### PR DESCRIPTION
To be compliant with CRAN guidelines:
- Prevent maven from creating persistent `.m2` directory, and
- Don't `rm` ivy and maven cache directories in test scripts.