### PR TITLE
Refactor schema extraction and normalize path for loading

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -9,7 +9,8 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
     jars = c(
       system.file(
         sprintf("java/mleap-%s-%s.jar", spark_version, scala_version),
-        package = "mleap"
+        package = "mleap",
+        mustWork = TRUE
       )
     ),
     packages = c(

--- a/R/prediction.R
+++ b/R/prediction.R
@@ -11,9 +11,10 @@ mleap_transform <- function(model, data) {
   
   columns <- colnames(data)
   
-  model_schema <- model$schema
+  input_schema <- model$schema[model$schema$io == "input",]
+
   types <- columns %>%
-    purrr::map_chr(~ model_schema$type[[match(.x, model_schema$name)]])
+    purrr::map_chr(~ input_schema$type[[match(.x, input_schema$name)]])
   
   schema <- list(fields = purrr::map2(
     columns, types, ~ list(name = .x, type = .y))

--- a/tests/testthat/output/iris_model_schema.txt
+++ b/tests/testthat/output/iris_model_schema.txt
@@ -1,10 +1,10 @@
-# A tibble: 7 x 4
-  name            type   nullable dimension
-  <chr>           <chr>  <lgl>    <chr>    
-1 Petal_Width     double TRUE     <NA>     
-2 Petal_Length    double TRUE     <NA>     
-3 predicted_label string TRUE     <NA>     
-4 features        double TRUE     (2)      
-5 prediction      double FALSE    <NA>     
-6 rawPrediction   double TRUE     (3)      
-7 probability     double TRUE     (3)      
+# A tibble: 7 x 5
+  name            type   nullable dimension io    
+  <chr>           <chr>  <lgl>    <chr>     <chr> 
+1 Petal_Width     double TRUE     <NA>      input 
+2 Petal_Length    double TRUE     <NA>      input 
+3 predicted_label string TRUE     <NA>      output
+4 features        double TRUE     (2)       output
+5 prediction      double FALSE    <NA>      output
+6 rawPrediction   double TRUE     (3)       output
+7 probability     double TRUE     (3)       output

--- a/tests/testthat/output/mtcars_model_schema.txt
+++ b/tests/testthat/output/mtcars_model_schema.txt
@@ -1,9 +1,9 @@
-# A tibble: 6 x 4
-  name       type   nullable dimension
-  <chr>      <chr>  <lgl>    <chr>    
-1 qsec       double TRUE     <NA>     
-2 hp         double FALSE    <NA>     
-3 wt         double TRUE     <NA>     
-4 big_hp     double FALSE    <NA>     
-5 features   double TRUE     (3)      
-6 prediction double FALSE    <NA>     
+# A tibble: 6 x 5
+  name       type   nullable dimension io    
+  <chr>      <chr>  <lgl>    <chr>     <chr> 
+1 qsec       double TRUE     <NA>      input 
+2 hp         double FALSE    <NA>      input 
+3 wt         double TRUE     <NA>      input 
+4 big_hp     double FALSE    <NA>      output
+5 features   double TRUE     (3)       output
+6 prediction double FALSE    <NA>      output


### PR DESCRIPTION
`mleap_model_schema()` now returns an extra column `io` specifying whether the column is an input or output column.