### PR TITLE
Updated Description / Support for Spark 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
-dist: trusty
 sudo: false
 cache: packages
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ language: R
 sudo: false
 cache: packages
 
+apt_packages:
+  - r-cran-rjava
+
 before_install:
-  - sudo apt update >/dev/null 2>&1   
-  - sudo apt install r-cran-rjava
-  - sudo R CMD javareconf
+  - sudo $(which R) CMD javareconf
 
 after_success:
-    - Rscript -e 'covr::codecov()'
+  - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 cache: packages
 
 before_install:
-  - Rscript -e 'install.packages(c("waldo", "covr", "ggplot2", "dplyr"))'
+  - Rscript -e 'install.packages(c("rJava", "waldo", "covr", "ggplot2", "dplyr"))'
 
 after_success:
     - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: false
 cache: packages
 
 before_install:
-  - Rscript -e 'install.packages(c("rJava", "waldo", "covr", "ggplot2", "dplyr"))'
+  - sudo apt update >/dev/null 2>&1   
+  - sudo apt install r-cran-rjava
 
 after_success:
     - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache: packages
 before_install:
   - sudo apt update >/dev/null 2>&1   
   - sudo apt install r-cran-rjava
+  - sudo R CMD javareconf
 
 after_success:
     - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ language: R
 sudo: false
 cache: packages
 
+before_install:
+  - Rscript -e 'install.packages(c("waldo", "covr", "ggplot2", "dplyr"))'
+
 after_success:
     - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,12 +17,12 @@ Encoding: UTF-8
 Depends:
   R (>= 3.1.2)
 Imports:
+  rJava,
   sparklyr,
   jsonlite,
   purrr,
   fs,
   tibble,
-  rJava,
   digest
 RoxygenNote: 6.1.1
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ BugReports: https://github.com/rstudio/mleap/issues
 License: Apache License (>= 2.0)
 SystemRequirements: Apache Spark 2.0+, Apache Maven 3.5+, Java JDK 8, MLeap Runtime 0.10.1+
 Encoding: UTF-8
-LazyData: true
 Depends:
   R (>= 3.1.2)
 Imports:

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,7 +1,7 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
   
   mleap_version <- if (spark_version >= "3.0.0") {
-    "0.19.0"
+    "0.18.0"
   } else if (spark_version >= "2.4.0") {
     "0.16.0"
   } else if (spark_version >= "2.3.0") {

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,5 +1,8 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
-  mleap_version <- if (spark_version >= "2.4.0") {
+  
+  mleap_version <- if (spark_version >= "3.0.0") {
+    "0.19.0"
+  } else if (spark_version >= "2.4.0") {
     "0.16.0"
   } else if (spark_version >= "2.3.0") {
     "0.13.0"

--- a/R/installers.R
+++ b/R/installers.R
@@ -149,7 +149,8 @@ mleap_found <- function(version = NULL) {
 #' Install MLeap runtime
 #' 
 #' @param dir (Optional) Directory to save the jars
-#' @param version Version of MLeap to install, defaults to the latest version tested with this package.
+#' @param mleap_version Version of MLeap to install, defaults to the latest version tested with this package.
+#' @param scala_version Version of Scala being used, defaults to version `2.11`.
 #' @param use_temp_cache Whether to use a temporary Maven cache directory for downloading.
 #'   Setting this to \code{TRUE} prevents Maven from creating a persistent \code{.m2/} directory.
 #'   Defaults to \code{TRUE}.
@@ -159,11 +160,11 @@ mleap_found <- function(version = NULL) {
 #' install_mleap()
 #' }
 #' @export
-install_mleap <- function(dir = NULL, version = NULL, use_temp_cache = TRUE) {
-  version <- version %||% .globals$default_mleap_version
+install_mleap <- function(dir = NULL, mleap_version = NULL, scala_version = "2.11", use_temp_cache = TRUE) {
+  mleap_version <- mleap_version %||% .globals$default_mleap_version
   
-  if (mleap_found(version)) {
-    message("MLeap Runtime version ", version, " already installed.")
+  if (mleap_found(mleap_version)) {
+    message("MLeap Runtime version ", mleap_version, " already installed.")
     return(invisible(NULL))
   }
   
@@ -172,20 +173,20 @@ install_mleap <- function(dir = NULL, version = NULL, use_temp_cache = TRUE) {
   
   mleap_dir <- if (!is.null(dir)) {
     normalizePath(
-      file.path(dir, paste0("mleap-", version)), 
+      file.path(dir, paste0("mleap-", mleap_version)), 
       mustWork = FALSE
     )
   } else {
-    install_dir(paste0("mleap/mleap-", version))
+    install_dir(paste0("mleap/mleap-", mleap_version))
   }
   
   if (!fs::dir_exists(mleap_dir))
     fs::dir_create(mleap_dir, recurse = TRUE)
   
-  message("Downloading MLeap Runtime ", version, "...")
+  message("Downloading MLeap Runtime ", mleap_version, "...")
   
   tryCatch(
-    download_jars(mvn, paste0("ml.combust.mleap:mleap-runtime_2.11:", version), mleap_dir,
+    download_jars(mvn, paste0("ml.combust.mleap:mleap-runtime_", scala_version, ":", mleap_version), mleap_dir,
                   use_temp_cache = use_temp_cache),
     error = function(e) {fs::dir_delete(mleap_dir); stop(e)}
   )
@@ -193,9 +194,9 @@ install_mleap <- function(dir = NULL, version = NULL, use_temp_cache = TRUE) {
   # download_jars(mvn, paste0("ml.combust.mleap:mleap-spark_2.11:", version), mleap_dir)
   .globals$mleap_dir <- dirname(mleap_dir)
   
-  load_mleap_jars(version)
+  load_mleap_jars(mleap_version)
   
-  message("MLeap Runtime version ", version, " installation succeeded.")
+  message("MLeap Runtime version ", mleap_version, " installation succeeded.")
   invisible(NULL)
 }
 

--- a/R/installers.R
+++ b/R/installers.R
@@ -89,8 +89,7 @@ install_maven <- function(dir = NULL, version = NULL) {
     stop("Maven installation failed. Unable to verify checksum.")
   }
   
-  status <- utils::untar(maven_path, compressed = "gzip",
-                         exdir = maven_dir)
+  status <- utils::untar(maven_path, exdir = maven_dir)
   if (!identical(status, 0L)) stop("Maven installation failed.", call. = FALSE)
   fs::file_delete(maven_path)
   

--- a/R/installers.R
+++ b/R/installers.R
@@ -181,7 +181,7 @@ install_mleap <- function(dir = NULL, version = NULL, use_temp_cache = TRUE) {
   }
   
   if (!fs::dir_exists(mleap_dir))
-    fs::dir_create(mleap_dir, recursive = TRUE)
+    fs::dir_create(mleap_dir, recurse = TRUE)
   
   message("Downloading MLeap Runtime ", version, "...")
   

--- a/inst/extdata/config.json
+++ b/inst/extdata/config.json
@@ -1,7 +1,7 @@
 [
   {
     "maven_version": "3.5.4",
-    "mleap_version": "0.12.0",
+    "mleap_version": "0.16.0",
     "maven_repo": "https://oss.sonatype.org/content/repositories/releases"
   }
 ]

--- a/tests/testthat/helpers-initialize.R
+++ b/tests/testthat/helpers-initialize.R
@@ -6,7 +6,7 @@ maven_dir <- file.path(temp, "maven")
 mleap_dir <- file.path(temp, "mleap")
 
 testthat_spark_connection <- function() {
-  version <- Sys.getenv("SPARK_VERSION", unset = "3.1.2")
+  version <- Sys.getenv("SPARK_VERSION", unset = "3.0.2")
 
   spark_installed <- sparklyr::spark_installed_versions()
   if (nrow(spark_installed[spark_installed$spark == version, ]) == 0) {

--- a/tests/testthat/helpers-initialize.R
+++ b/tests/testthat/helpers-initialize.R
@@ -6,7 +6,7 @@ maven_dir <- file.path(temp, "maven")
 mleap_dir <- file.path(temp, "mleap")
 
 testthat_spark_connection <- function() {
-  version <- Sys.getenv("SPARK_VERSION", unset = "2.4.0")
+  version <- Sys.getenv("SPARK_VERSION", unset = "3.1.2")
 
   spark_installed <- sparklyr::spark_installed_versions()
   if (nrow(spark_installed[spark_installed$spark == version, ]) == 0) {

--- a/tests/testthat/helpers-initialize.R
+++ b/tests/testthat/helpers-initialize.R
@@ -6,7 +6,7 @@ maven_dir <- file.path(temp, "maven")
 mleap_dir <- file.path(temp, "mleap")
 
 testthat_spark_connection <- function() {
-  version <- Sys.getenv("SPARK_VERSION", unset = "3.0.2")
+  version <- Sys.getenv("SPARK_VERSION", unset = "2.4.5")
 
   spark_installed <- sparklyr::spark_installed_versions()
   if (nrow(spark_installed[spark_installed$spark == version, ]) == 0) {

--- a/tests/testthat/output/iris_model_schema.txt
+++ b/tests/testthat/output/iris_model_schema.txt
@@ -1,4 +1,4 @@
-# A tibble: 7 x 5
+# A tibble: 7 × 5
   name            type   nullable dimension io    
   <chr>           <chr>  <lgl>    <chr>     <chr> 
 1 Petal_Width     double TRUE     <NA>      input 

--- a/tests/testthat/output/mtcars_model_schema.txt
+++ b/tests/testthat/output/mtcars_model_schema.txt
@@ -1,4 +1,4 @@
-# A tibble: 6 x 5
+# A tibble: 6 × 5
   name       type   nullable dimension io    
   <chr>      <chr>  <lgl>    <chr>     <chr> 
 1 qsec       double TRUE     <NA>      input 


### PR DESCRIPTION
`LazyData: true` seems to be the only indication as to why mleap has been removed from CRAN.

There is no `data/` folder so we can omit this and avoid the note occurring.